### PR TITLE
Remove experimental from astro.config.mjs for future compatibility.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,7 +13,4 @@ export default defineConfig({
     robotsTxt()
   ],
   site: 'https://simple-astro-blog.vercel.app',
-  experimental: {
-    integrations: true
-  }
 })


### PR DESCRIPTION
Using Experimental.integrations in `astro.config.mjs` causes an error.

```
13:06:05 [astro] Unable to load C:\work\jamstack\simple-astro-blog\astro.config.mjs

 error   Invalid experimental key: `integrations`.
  Make sure the spelling is correct, and that your Astro version supports this experiment.
  See https://docs.astro.build/en/reference/configuration-reference/#experimental-flags for more information.
```

Astro 2.5 added (https://github.com/withastro/astro/commit/cada10a466f81f8edb0aa664f9cffdb6b5b8f307) Thanks [@TheOtterlord](https://github.com/TheOtterlord)! - Throw an error when unknown experimental keys are present.

And right now `Astro/Image` will force the update to Astro 2.5.